### PR TITLE
Pets no longer teleport on unload when sitting

### DIFF
--- a/src/dk/fido2603/mydog/listeners/WolfMainListener.java
+++ b/src/dk/fido2603/mydog/listeners/WolfMainListener.java
@@ -528,7 +528,7 @@ public class WolfMainListener implements Listener
 		for (Entity e : entities)
 		{
 			// All tameables
-			if (e != null && e instanceof Sittable && e instanceof Tameable)
+			if (e != null && e instanceof Sittable && e instanceof Tameable && !((Sittable)e).isSitting())
 			{
 				HashMap<Boolean, Location> teleportResult = teleportTameable(e, safeLocation, null);
 


### PR DESCRIPTION
# Changes
* Pets will no longer teleport to the player when they are sitting and the chunk they are in unloads.

# Reason for change
Randomly, all your pets will teleport to you when running in the nether - even if sitting. This happens when the previous chunk unloaded and so now all your lovely pets are now on fire, burning, dying, and may about to try swimming in lava. I've lost pets before to this, and I'm sick of roaming the nether without being able to leave my pets behind. This should fix that change.

Thanks for reading. :)